### PR TITLE
Fix comment string matching

### DIFF
--- a/syntax/conkyrc.vim
+++ b/syntax/conkyrc.vim
@@ -10,7 +10,7 @@ if exists("b:current_syntax")
 	finish
 endif
 
-syn region ConkyrcComment start=/^\s*#/ end=/$/
+syn region ConkyrcComment start=/\s*#/ end=/$/
 
 syn keyword ConkyrcSetting alignment append_file background border_inner_margin border_outer_margin border_width color0 color1 color2 color3 color4 color5 color6 color7 color8 color9 colorN cpu_avg_samples default_bar_size default_color default_gauge_size default_graph_size default_outline_color default_shade_color diskio_avg_samples display double_buffer draw_borders draw_graph_borders draw_outline draw_shades extra_newline font format_human_readable gap_x gap_y if_up_strictness imap imlib_cache_flush_interval imlib_cache_size lua_draw_hook_post lua_draw_hook_pre lua_load lua_shutdown_hook lua_startup_hook mail_spool max_port_monitor_connections max_specials max_text_width max_user_text maximum_width minimum_size mpd_host mpd_password mpd_port music_player_interval net_avg_samples no_buffers nvidia_display out_to_console out_to_ncurses out_to_stderr out_to_x override_utf8_locale overwrite_file own_window own_window_class own_window_colour own_window_hints own_window_title own_window_transparent own_window_type pad_percents pop3 sensor_device short_units show_graph_range show_graph_scale stippled_borders temperature_unit template template0 template1 template2 template3 template4 template5 template6 template7 template8 template9 text text_buffer_size times_in_seconds top_cpu_separate top_name_width total_run_times update_interval update_interval_on_battery uppercase use_spacer use_xft xftalpha xftfont
 


### PR DESCRIPTION
Comments in `.conkyrc` don't have to be at the beginning of the line. The following works fine as well:

```
# Fonts.
use_xft yes
xftfont Liberation Mono:size=13
uppercase no

# Solarized colors.
default_color 839496  # primary text
color1 93a1a1  # emphesized text
color2 586e75  # secondary text
color3 dc322f  # red
```